### PR TITLE
Improve coverage gates

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,22 +10,3 @@ jobs:
     uses: ectobit/reusable-workflows/.github/workflows/go-check.yaml@main
     with:
       test-command: make test
-
-  coverage:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: 1.26.4
-
-      - name: Check coverage
-        run: |
-          set -euo pipefail
-
-          go test -coverprofile=coverage.out ./...
-          coverage="$(go tool cover -func=coverage.out | awk '/^total:/ { sub(/%/, "", $3); print $3 }')"
-          echo "Coverage: ${coverage}%"
-          awk -v coverage="$coverage" 'BEGIN { exit coverage >= 90.0 ? 0 : 1 }'

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	echo "$$report"; \
 	coverage=$$(printf "%s\n" "$$report" | awk '/^total:/ {gsub(/%/, "", $$3); print $$3}'); \
 	badge=$$(awk -F'coverage-|%25' '/img.shields.io\/badge\/coverage-/ {print $$2; exit}' README.md); \
-	threshold=$${COVERAGE_THRESHOLD:-90}; \
+	threshold="$(COVERAGE_THRESHOLD)"; \
 	if [ -z "$$coverage" ]; then echo "coverage total not found" && exit 1; fi; \
 	if [ -z "$$badge" ]; then echo "README coverage badge not found" && exit 1; fi; \
 	if [ "$$coverage" != "$$badge" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,25 @@
-COVERAGE_THRESHOLD ?= 90.0
+COVERAGE_THRESHOLD ?= 95.0
 
-.PHONY: lint test testv test-cov update
+.PHONY: lint test update
 
 lint:
 	@golangci-lint run
 
 test:
-	@go test ./...
-
-testv:
-	@go test -v ./...
-
-test-cov:
-	@go test -coverprofile=coverage.out ./...
-	@coverage_report="$$(go tool cover -func coverage.out)"; \
-		echo "$${coverage_report}"; \
-		coverage="$$(printf '%s\n' "$${coverage_report}" | awk '/^total:/ { sub(/%/, "", $$3); print $$3 }')"; \
-		echo "Coverage: $${coverage}%"; \
-		awk -v coverage="$${coverage}" -v threshold="$(COVERAGE_THRESHOLD)" 'BEGIN { exit coverage >= threshold ? 0 : 1 }'
+	@go test -race -coverprofile=coverage.out ./...
+	@report=$$(go tool cover -func coverage.out); \
+	echo "$$report"; \
+	coverage=$$(printf "%s\n" "$$report" | awk '/^total:/ {gsub(/%/, "", $$3); print $$3}'); \
+	badge=$$(awk -F'coverage-|%25' '/img.shields.io\/badge\/coverage-/ {print $$2; exit}' README.md); \
+	threshold=$${COVERAGE_THRESHOLD:-90}; \
+	if [ -z "$$coverage" ]; then echo "coverage total not found" && exit 1; fi; \
+	if [ -z "$$badge" ]; then echo "README coverage badge not found" && exit 1; fi; \
+	if [ "$$coverage" != "$$badge" ]; then \
+		echo "README coverage badge $$badge% does not match measured coverage $$coverage%" && exit 1; \
+	fi; \
+	awk "BEGIN { exit !($$coverage >= $$threshold) }" || \
+		(echo "coverage $$coverage% is below $$threshold%" && exit 1)
 
 update:
-	@go get -u
+	@go get -u all
+	@go mod tidy

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Microservices oriented [12-factor](https://12factor.net) Go library for parsing 
 [![pipeline](https://github.com/acim/bee/actions/workflows/pipeline.yml/badge.svg)](https://github.com/acim/bee/actions/workflows/pipeline.yml)
 [![reference](https://pkg.go.dev/badge/go.acim.net/bee.svg)](https://pkg.go.dev/go.acim.net/bee)
 [![report](https://goreportcard.com/badge/go.acim.net/bee)](https://goreportcard.com/report/go.acim.net/bee)
-![coverage](https://img.shields.io/badge/coverage-95.8%25-brightgreen?style=flat&logo=go)
+![coverage](https://img.shields.io/badge/coverage-99.0%25-brightgreen?style=flat&logo=go)
 
 This package in intended to be used to parse command line arguments and environment variables into an arbitrary config struct.
 This struct may contain multiple nested structs, they all will be processed recursively. Names of the flags and environment
@@ -39,7 +39,7 @@ Besides the types supported by flag package, this package provides additional ty
 
 ## [Examples](example_test.go)
 
-Run `make testv` to see examples output.
+Run `go test -v` to see examples output.
 
 ## Service setup
 

--- a/command_line.go
+++ b/command_line.go
@@ -447,11 +447,11 @@ func (cl *comandLine) exit(err error) error {
 		return err
 	case flag.ExitOnError:
 		if cl.help || errors.Is(err, flag.ErrHelp) {
-			os.Exit(0)
+			osExit(0)
 		}
 
 		_, _ = fmt.Fprintf(cl.output, "bee: %v\n", err)
-		os.Exit(2) //nolint:gomnd
+		osExit(2) //nolint:gomnd
 	case flag.PanicOnError:
 		panic(err)
 	}

--- a/command_line_internal_test.go
+++ b/command_line_internal_test.go
@@ -2,6 +2,7 @@ package bee
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -129,6 +130,54 @@ func TestParse_duplicateFlagReturnsError(t *testing.T) {
 	}{}, []string{})
 
 	assertError(t, err, `Second def: duplicate flag "same": invalid config type`)
+}
+
+func TestExitOnErrorWritesErrorAndExits(t *testing.T) {
+	var output bytes.Buffer
+	cl := newCommandLine("test")
+	cl.output = &output
+	cl.errorHandling = flag.ExitOnError
+
+	gotCode := captureExit(t, func() {
+		_ = cl.exit(errors.New("bad flag"))
+	})
+
+	if gotCode != exitCode {
+		t.Fatalf("want exit code %d, got %d", exitCode, gotCode)
+	}
+
+	if got, want := output.String(), "bee: bad flag\n"; got != want {
+		t.Fatalf("want output %q, got %q", want, got)
+	}
+}
+
+func TestExitOnErrorHelpExitsSuccessfully(t *testing.T) {
+	cl := newCommandLine("test")
+	cl.errorHandling = flag.ExitOnError
+	cl.help = true
+
+	gotCode := captureExit(t, func() {
+		_ = cl.exit(flag.ErrHelp)
+	})
+
+	if gotCode != 0 {
+		t.Fatalf("want exit code 0, got %d", gotCode)
+	}
+}
+
+func TestPanicOnErrorPanics(t *testing.T) {
+	t.Parallel()
+
+	cl := newCommandLine("test")
+	cl.errorHandling = flag.PanicOnError
+
+	defer func() {
+		if got := recover(); got != flag.ErrHelp {
+			t.Fatalf("want panic %v, got %v", flag.ErrHelp, got)
+		}
+	}()
+
+	_ = cl.exit(flag.ErrHelp)
 }
 
 func TestParse_usage(t *testing.T) { //nolint:funlen

--- a/coverage_policy_test.go
+++ b/coverage_policy_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestMakefileTestCovEnforcesCoverageThreshold(t *testing.T) {
+func TestMakefileTestEnforcesCoverageThreshold(t *testing.T) {
 	makefileBytes, err := os.ReadFile("Makefile")
 	if err != nil {
 		t.Fatal(err)
@@ -14,15 +14,27 @@ func TestMakefileTestCovEnforcesCoverageThreshold(t *testing.T) {
 
 	makefile := string(makefileBytes)
 
-	if !strings.Contains(makefile, "COVERAGE_THRESHOLD ?= 90.0") {
-		t.Fatal("Makefile must define the 90% coverage threshold")
+	if !strings.Contains(makefile, ".PHONY: lint test update") {
+		t.Fatal("Makefile must only define the test action for running tests")
 	}
 
-	if !strings.Contains(makefile, `coverage >= threshold`) {
-		t.Fatal("make test-cov must fail when total coverage is below the threshold")
+	if !strings.Contains(makefile, "COVERAGE_THRESHOLD ?= 95.0") {
+		t.Fatal("Makefile must define the 95% coverage threshold")
+	}
+
+	if !strings.Contains(makefile, "go test -race -coverprofile=coverage.out ./...") {
+		t.Fatal("make test must run the race detector and collect coverage")
+	}
+
+	if !strings.Contains(makefile, "README coverage badge $$badge% does not match measured coverage $$coverage%") {
+		t.Fatal("make test must fail when the README coverage badge is stale")
+	}
+
+	if !strings.Contains(makefile, `$$coverage >= $$threshold`) {
+		t.Fatal("make test must fail when total coverage is below the threshold")
 	}
 
 	if count := strings.Count(makefile, "go tool cover -func coverage.out"); count != 1 {
-		t.Fatalf("make test-cov must only generate the coverage report once, found %d", count)
+		t.Fatalf("make test must only generate the coverage report once, found %d", count)
 	}
 }

--- a/coverage_policy_test.go
+++ b/coverage_policy_test.go
@@ -22,6 +22,10 @@ func TestMakefileTestEnforcesCoverageThreshold(t *testing.T) {
 		t.Fatal("Makefile must define the 95% coverage threshold")
 	}
 
+	if !strings.Contains(makefile, `threshold="$(COVERAGE_THRESHOLD)"`) {
+		t.Fatal("make test must use the Makefile coverage threshold")
+	}
+
 	if !strings.Contains(makefile, "go test -race -coverprofile=coverage.out ./...") {
 		t.Fatal("make test must run the race detector and collect coverage")
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module go.acim.net/bee
 
-go 1.18
+go 1.23
 
 require (
-	github.com/go-chi/chi/v5 v5.2.3
+	github.com/go-chi/chi/v5 v5.3.0
 	github.com/iancoleman/strcase v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
-github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
+github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=

--- a/service.go
+++ b/service.go
@@ -19,6 +19,8 @@ const (
 	exitCode                   = 2
 )
 
+var osExit = os.Exit
+
 // Service is an microservice abstraction providing graceful shutdown.
 type Service struct {
 	name        string
@@ -149,7 +151,7 @@ func Exit(m string, err error) {
 		_, _ = fmt.Fprintf(os.Stderr, "%s: %s\n", m, err)
 	}
 
-	os.Exit(exitCode)
+	osExit(exitCode)
 }
 
 // SlogError create slog string attribute to handle error logs.

--- a/service_internal_test.go
+++ b/service_internal_test.go
@@ -9,9 +9,46 @@ import (
 	"log/slog"
 	"os"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
+
+var exitFuncMu sync.Mutex
+
+type exitPanic int
+
+func captureExit(t *testing.T, fn func()) (code int) {
+	t.Helper()
+
+	exitFuncMu.Lock()
+	t.Cleanup(func() {
+		osExit = os.Exit
+		exitFuncMu.Unlock()
+	})
+
+	osExit = func(code int) {
+		panic(exitPanic(code))
+	}
+
+	defer func() {
+		got := recover()
+		if got == nil {
+			t.Fatal("want exit, got return")
+		}
+
+		exit, ok := got.(exitPanic)
+		if !ok {
+			panic(got)
+		}
+
+		code = int(exit)
+	}()
+
+	fn()
+
+	return code
+}
 
 func TestServiceOptions(t *testing.T) {
 	t.Parallel()
@@ -146,6 +183,117 @@ func TestSlogError(t *testing.T) {
 	attr := SlogError(flag.ErrHelp)
 	if attr.Key != "error" || attr.Value.String() != flag.ErrHelp.Error() {
 		t.Fatalf("want error attr for %q, got %s=%s", flag.ErrHelp, attr.Key, attr.Value)
+	}
+}
+
+func TestExitWritesMessageAndExits(t *testing.T) {
+	var output bytes.Buffer
+	stderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		os.Stderr = stderr
+		_ = r.Close()
+	})
+
+	os.Stderr = w
+
+	gotCode := captureExit(t, func() {
+		Exit("stopping", errors.New("boom"))
+	})
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := output.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotCode != exitCode {
+		t.Fatalf("want exit code %d, got %d", exitCode, gotCode)
+	}
+
+	if got, want := output.String(), "stopping: boom\n"; got != want {
+		t.Fatalf("want stderr %q, got %q", want, got)
+	}
+}
+
+func TestExitWritesMessageWithoutError(t *testing.T) {
+	var output bytes.Buffer
+	stderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		os.Stderr = stderr
+		_ = r.Close()
+	})
+
+	os.Stderr = w
+
+	gotCode := captureExit(t, func() {
+		Exit("stopping", nil)
+	})
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := output.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotCode != exitCode {
+		t.Fatalf("want exit code %d, got %d", exitCode, gotCode)
+	}
+
+	if got, want := output.String(), "stopping\n"; got != want {
+		t.Fatalf("want stderr %q, got %q", want, got)
+	}
+}
+
+func TestNewServiceExitsOnParseError(t *testing.T) {
+	var output bytes.Buffer
+	args := os.Args
+	stderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		os.Args = args
+		os.Stderr = stderr
+		_ = r.Close()
+	})
+
+	os.Args = []string{"test"}
+	os.Stderr = w
+
+	gotCode := captureExit(t, func() {
+		_ = NewService("test", []string{}, WithErrorHandling(flag.ContinueOnError))
+	})
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := output.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotCode != exitCode {
+		t.Fatalf("want exit code %d, got %d", exitCode, gotCode)
+	}
+
+	if got, want := output.String(), "failed parsing command line: invalid config type\n"; got != want {
+		t.Fatalf("want stderr %q, got %q", want, got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- consolidate Makefile testing into a single race+coverage target with README badge validation
- raise coverage to 99.0% and enforce a 95.0% threshold
- update dependencies with make update
- remove stale duplicate CI coverage gate

## Validation
- go test -run TestMakefileTestEnforcesCoverageThreshold ./...
- make test
- make COVERAGE_THRESHOLD=100.0 test (fails as expected)
- actionlint